### PR TITLE
Changed to not require any node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 var AWS = require('aws-sdk');
-var _ = require('lodash');
-AWS.config.setPromisesDependency(require('bluebird'));
 var ec2 = new AWS.EC2({region: "us-east-1"});
 
 const filterTagName = "RevokeAllIngressAtMidnight";
@@ -13,27 +11,28 @@ const params = {
 
 
 function resetSecurityGroupRules(event, context, callback) {
-	console.log("Describing security groups...");
-	ec2.describeSecurityGroups(params).promise().then(function(groups){
+  console.log("Describing security groups...");
+  ec2.describeSecurityGroups(params).promise().then(function(groups) {
     console.log(`Successfully described security groups: ${JSON.stringify(groups)}`);
-    return groups.SecurityGroups;
-  }).map(revokeSecurityGroupIngress).all(function(resultArray){
-    console.log(`Successfully revoked all permissions.  resultArray=${JSON.stringify(resultArray)}`);
-    callback(null, `Successfully revoked all permissions.  resultArray=${JSON.stringify(resultArray)}`);
-  }).catch(function(err){
+    let promises = groups.SecurityGroups.map(revokeSecurityGroupIngress);
+    Promise.all(promises).then(resultArray => {
+      console.log(`Successfully revoked all permissions.  resultArray=${JSON.stringify(resultArray)}`);
+      callback(null, `Successfully revoked all permissions.  resultArray=${JSON.stringify(resultArray)}`);
+    })
+  }).catch(function(err) {
     console.log(`ERROR revoking security groups.  err=${JSON.stringify(err)}`);
     callback(err);
-  });
+  })
 }
 
-function revokeSecurityGroupIngress(group){
-  if(group.IpPermissions.length > 0){
+function revokeSecurityGroupIngress(group) {
+  if (group.IpPermissions.length > 0) {
     var revokeParams = {
-      IpPermissions: _.map(group.IpPermissions, mapIpPermissions),
+      IpPermissions: group.IpPermissions.map(mapIpPermissions),
       GroupId: group.GroupId
     };
     console.log(`Promising to  to revoke permissions with the following params: ${JSON.stringify(revokeParams)}`);
-    return ec2.revokeSecurityGroupIngress(revokeParams).promise().then(function(data){
+    return ec2.revokeSecurityGroupIngress(revokeParams).promise().then(function(data) {
       console.log(`Successfully revoked permissions on group "${group.GroupName}"`);
       return `Successfully revoked permissions on group "${group.GroupName}"`;
     });
@@ -43,7 +42,7 @@ function revokeSecurityGroupIngress(group){
   }
 }
 
-function mapIpPermissions(item){
+function mapIpPermissions(item) {
   return {
     FromPort: item.FromPort,
     IpProtocol: item.IpProtocol,

--- a/package.json
+++ b/package.json
@@ -4,14 +4,11 @@
   "description": "",
   "main": "revoke-all-sg-rules.js",
   "dependencies": {
-    "aws-sdk": "^2.85.0",
-    "bluebird": "^3.5.0",
-    "lodash": "^4.17.4"
+    "aws-sdk": "^2.85.0"
   },
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "package": "echo 'Packaging for lambda upload' && zip -r lambda-revoke-sg.zip node_modules index.js"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
Removes lodash and bluebird (both amazing libraries, but for Lambdas, I find it nice just to use the nodejs functions unless it is really painful).   

the aws=sdk is automatically available, so you can now copy and paste this into the inline console or upload the single file to the s3 (no need to package a zip)